### PR TITLE
UPDATE: depend. versions and resolve systemProperty deprecated warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
 
+        <wave-version>1.3.2-SNAPSHOT</wave-version>
+        <flow-version>1.1.1</flow-version>
         <maven-surefire-plugin>2.22.2</maven-surefire-plugin>
         <maven-compiler-plugin>3.8.1</maven-compiler-plugin>
         <maven.surefire.plugin.version>2.21.0</maven.surefire.plugin.version>
         <allure-version>2.14.0</allure-version>
         <allure.maven.version>2.10.0</allure.maven.version>
         <allure.report.version>2.10.0</allure.report.version>
-        <aspectj.version>1.9.1</aspectj.version>
+        <aspectj.version>1.9.20</aspectj.version>
         <parallelSessions>4</parallelSessions>
         <tagName>@add</tagName>
         <tagNameTwo>@add</tagNameTwo>
@@ -41,12 +43,12 @@
         <dependency>
             <groupId>io.github.tidal-code</groupId>
             <artifactId>wave</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>${wave-version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.tidal-code</groupId>
             <artifactId>flow</artifactId>
-            <version>1.0.0</version>
+            <version>${flow-version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.tidal-code</groupId>
@@ -86,24 +88,12 @@
                         or ${wipTag})"
                         -Dcucumber.execution.dry-run=${dryRun}
                     </argLine>
-                    <systemProperties>
-                        <property>
-                            <name>parallel</name>
-                            <value>methods</value>
-                        </property>
-                        <property>
-                            <name>perCoreThreadCount</name>
-                            <value>false</value>
-                        </property>
-                        <property>
-                            <name>dataproviderthreadcount</name>
-                            <value>${parallelSessions}</value>
-                        </property>
-                        <property>
-                            <name>allure.results.directory</name>
-                            <value>${basedir}/target/allure-results</value>
-                        </property>
-                    </systemProperties>
+                    <systemPropertyVariables>
+                        <parallel>methods</parallel>
+                        <perCoreThreadCount>false</perCoreThreadCount>
+                        <dataproviderthreadcount>${parallelSessions}</dataproviderthreadcount>
+                        <allure.results.directory>${basedir}/target/allure-results</allure.results.directory>
+                    </systemPropertyVariables>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
Resolve the deprecated warning when running code by replacing <systemProperties> with <systemPropertyVariables>.
Also, upgrade wave snapshot to resolve Chrome driver 114 error.